### PR TITLE
A helper macro for load bootstrap

### DIFF
--- a/cl-bootstrap.asd
+++ b/cl-bootstrap.asd
@@ -27,6 +27,6 @@
                         (:file "accordion")
                         (:file "button-dropdowns")
                         (:file "forms")
-                        (:file "bootstrap-helper"))))
+                        (:file "bootstrap-helper")))))
 
 ;; EOF

--- a/cl-bootstrap.asd
+++ b/cl-bootstrap.asd
@@ -26,6 +26,7 @@
                         (:file "navbar")
                         (:file "accordion")
                         (:file "button-dropdowns")
-                        (:file "forms")))))
+                        (:file "forms")
+                        (:file "bootstrap-helper"))))
 
 ;; EOF

--- a/packages.lisp
+++ b/packages.lisp
@@ -60,6 +60,10 @@
 	     #:bs-accordion-item
 	     #:bs-form-email
              
+	     #:*bootstrap-css-url*
+	     #:*jquery-url*
+	     #:*bootstrap-js-url*
+	     #:bs-page
              ))
 
 

--- a/src/bootstrap-helper.lisp
+++ b/src/bootstrap-helper.lisp
@@ -1,0 +1,20 @@
+(in-package :cl-bootstrap)
+
+(defparameter *bootstrap-css-url* "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css")
+(defparameter *jquery-url*  "https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js")
+(defparameter *bootstrap-js-url* "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js")
+
+(defmacro bs-page ((&rest header) &body body)
+  `(with-html-output-to-string (*standard-output* nil
+						  :prologue "<!DOCTYPE html>")
+     (:html
+      (:head
+       (:meta :charset "utf-8")
+       (:meta :name "viewport" :content "width=device-width,initial-scale=1")
+       (:link :rel "stylesheet" :href ,*bootstrap-css-url*)
+       (:script :src ,*jquery-url*)
+       (:script :src ,*bootstrap-js-url*)
+       ,@header)
+      (:body
+       ,@body))))
+


### PR DESCRIPTION
Thanks for your job. cl-bootstrap helps me a lot in design web pages. Without it, I have to write a lot bootstrap element by hand. I add a small macro for a page with bootstrap loaded, since the first time I use cl-bootstrap it doesn't load bootstrap.css and it may be more convenient for users to have it autoloaded. Also, as I use webpage in ningle, each route is related to a function returning string, not print directly, so I use with-html-output-to-string instead of with-html-output. If a user want print, he or she may simply (print (bs-page ...)).
